### PR TITLE
Increased length for password validation regex check

### DIFF
--- a/lib/src/validator_base.dart
+++ b/lib/src/validator_base.dart
@@ -19,7 +19,7 @@ final RegExp _htmlTagsRegex = new RegExp(
     r"^<(?:([A-Za-z][A-Za-z0-9]*)\b[^>]*>(?:.*?)</\1>|[A-Za-z][A-Za-z0-9]*\b[^/>]*/>)$",
     multiLine: true);
 final RegExp _passwordRegex = new RegExp(
-    r"^(?=.*\d)(?=.*[~!@#$%^&*()_\-+=|\\{}[\]:;<>?/])(?=.*[A-Z])(?=.*[a-z])\S{8,15}$");
+    r"^(?=.*\d)(?=.*[~!@#$%^&*()_\-+=|\\{}[\]:;<>?/])(?=.*[A-Z])(?=.*[a-z])\S{8,99}$");
 final RegExp _creditCardRegex = new RegExp(
     r"^(?:3[47]\d{2}([\- ]?)\d{6}\1\d{5}|(?:4\d{3}|5[1-5]\d{2}|6011)([\- ]?)\d{4}\2\d{4}\2\d{4})$");
 


### PR DESCRIPTION
The regex for validating passwords did so for only the first 15 characters of a string and ignored the following characters. Increased to 99 instead. A better solution might be to use regex for unspecified number of characters but this quick fix probably solves most use cases related to this issue.